### PR TITLE
Don't depend on conf-libev

### DIFF
--- a/aeio.opam
+++ b/aeio.opam
@@ -14,7 +14,6 @@ depends: [
   "ocamlbuild" {build}
   "lwt"
   "lwt-dllist"
-  "conf-libev"
 ]
 depopts: []
 build: [

--- a/aeio.opam
+++ b/aeio.opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "https://github.com/kayceesrk/ocaml-aeio.git"
 bug-reports: "https://github.com/kayceesrk/ocaml-aeio/issues"
 tags: []
-version: "0.3.0"
+version: "0.3.1"
 available: [ ocaml-version >= "4.10.0"]
 depends: [
   "ocamlfind" {build}


### PR DESCRIPTION
This allows users to optionally choose the select backend for Lwt.

Also bump the version while we're at it.